### PR TITLE
Upload boostrap frequencies

### DIFF
--- a/rclone_upload.py
+++ b/rclone_upload.py
@@ -35,6 +35,7 @@ readme={'README.txt':'This file',
         'crossmatch-2.fits':'Bootstrap catalogue iteration 2',
         'crossmatch-results-1.npy':'Bootstrap results iteration 1',
         'crossmatch-results-2.npy':'Bootstrap results iteration 2',
+        'frequencies.txt':'Frequencies used for the bootstrap',
         'astromap.fits':'Astrometry accuracy map',
         'image_full_ampphase_di_m.NS.app.restored.fits':'Full-resolution final image in apparent flux',
         'image_full_ampphase_di_m.NS.psf.fits':'Full-resolution final PSF image',
@@ -251,7 +252,8 @@ def upload_field(name,basedir=None,split_uv=False,skip_fits=False):
                    m.glob('*-fit_state.pickle') +
                    m.glob('*.png') +
                    m.glob('*crossmatch-results*') +
-                   m.glob('*crossmatch-*.fits'),readme=True)
+                   m.glob('*crossmatch-*.fits') +
+                   m.glob('*frequencies.txt'),readme=True)
 
     update_status(name,'Created tar',workdir=workdir)
     report('Uploading')

--- a/upload.py
+++ b/upload.py
@@ -125,6 +125,7 @@ def do_upload(name,basedir,skipstokes=False):
         f+=myglob('image_full_low_QU.cube.*',workdir)
         f+=myglob('image_full_vlow_QU.cube.*',workdir)
     f+=myglob('*.archive',workdir)
+    f+=myglob('*frequencies.txt',workdir)
 
     do_rsync(name,basedir,f)
     compressed_done=(len(myglob('*.archive',workdir))>0)


### PR DESCRIPTION
For long baseline reductions we subtract the LoTSS model when doing widefield imaging. This means we also need to apply the bootstrap corrections to the unaveraged input data. As far as I could tell, the bootstrap factors are uploaded, but not the frequencies from which they were derived, which are used in the spline interpolation to all the bands. After checking with @twshimwell where to add them, this pull request should add the file containing the frequencies (`L*frequencies.txt`) to the uploaded files.